### PR TITLE
Add tag output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For more information on these outputs, see the [API Documentation](https://devel
 - `id`: The release ID
 - `html_url`: The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`
 - `upload_url`: The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset`](https://www.github.com/actions/upload-release-asset) GitHub Action
+- `tag`: The simple tag name
 
 ### Example workflow - create a release
 On every `push` to a tag matching the pattern `v*`, [create a release](https://developer.github.com/v3/repos/releases/#create-a-release):

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -39,6 +39,7 @@ async function run() {
     core.setOutput('id', releaseId);
     core.setOutput('html_url', htmlUrl);
     core.setOutput('upload_url', uploadUrl);
+    core.setOutput('tag', tag);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
When the release is created, uploading the asset file name need a simple tag name,like `demo-v1.0.0.exe`.
I try use **${{ github.ref }}** but get `refs/tags/xxx`，so I hope can return a simple tag name.