### PR TITLE
Add workflow to automate versioning

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,15 @@
+name: Keep the versions up-to-date
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        with:
+          publish_latest: true
+        env:
+          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'


### PR DESCRIPTION
This PR adds a workflow using the the [actions-tagger](https://github.com/marketplace/actions/actions-tagger) action to automate sliding major version numbers when a new release is published.