### PR TITLE
Add body-command argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   body:
     description: 'Text describing the contents of the tag.'
     required: false
+    default: ''
+  body-command: 
+    description: 'Command to run which the output to generate the body of the release. Note, this will append to the body defined.'
+    required: false
   draft:
     description: '`true` to create a draft (unpublished) release, `false` to create a published one. Default: `false`'
     required: false

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core');
 const { GitHub, context } = require('@actions/github');
+const exec = require('@actions/exec');
 
 async function run() {
   try {
@@ -16,8 +17,19 @@ async function run() {
     const tag = tagName.replace('refs/tags/', '');
     const releaseName = core.getInput('release_name', { required: true }).replace('refs/tags/', '');
     const body = core.getInput('body', { required: false });
+    const bodyCommand = core.getInput('body-command', {required: false});
     const draft = core.getInput('draft', { required: false }) === 'true';
     const prerelease = core.getInput('prerelease', { required: false }) === 'true';
+
+    if (bodyCommand) {
+      const options = {};
+      options.listeners = {
+        stdout: (data) => {
+          body += data.toString();
+        }
+      };
+      await exec.exec(bodyCommand, [], options);
+    }
 
     // Create a release
     // API Documentation: https://developer.github.com/v3/repos/releases/#create-a-release


### PR DESCRIPTION
Adds an argument to allow users to generate a release body
from a bash command instead of defining it as a string.