### PR TITLE
document how to create a release using the contents of a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,9 @@ jobs:
         uses: actions/checkout@master
       - name: Read Release Notes
         id: release_notes
-        run: |
-          CONTENTS="$(cat release_notes_latest.md)"
-          # allow to save as multiline string https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-          CONTENTS="${CONTENTS//'%'/'%25'}"
-          CONTENTS="${CONTENTS//$'\n'/'%0A'}"
-          CONTENTS="${CONTENTS//$'\r'/'%0D'}" 
-          # set an output parameter https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
-          echo "::set-output name=contents::$CONTENTS"
+        juliangruber/read-file-action@v1
+        with:
+          path: ./release_notes_latest.md
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
@@ -60,7 +55,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body: ${{ steps.release_notes.outputs.contents }}  # file contents taken from earlier step
+          body: ${{ steps.release_notes.outputs.content }}  # file contents taken from earlier step
           draft: false
           prerelease: false
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@master
+      - name: Read Release Notes
+        id: release_notes
+        run: |
+          CONTENTS="$(cat release_notes_latest.md)"
+          # allow to save as multiline string https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
+          CONTENTS="${CONTENTS//'%'/'%25'}"
+          CONTENTS="${CONTENTS//$'\n'/'%0A'}"
+          CONTENTS="${CONTENTS//$'\r'/'%0D'}" 
+          # set an output parameter https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+          echo "::set-output name=contents::$CONTENTS"
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
@@ -50,10 +60,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
+          body: ${{ steps.release_notes.outputs.contents }}  # file contents taken from earlier step
           draft: false
           prerelease: false
 ```


### PR DESCRIPTION
Document in the README example how to use the contents of a file as the body of the release. I chose to replace the static example with one that reads from a file as I do not believe it is likely that many people will want the release notes to be the same every time.

I additionally chose to include this example as it is surprisingly non-trivial to read the contents and pass them on to the action as one will need to know how to use [workflow actions](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions) and that [multi-line strings need to be escaped](https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322). This points them to an action that will handle everything for them.