### PR TITLE
release_name is flagged as required despite it is optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   release_name:
     description: 'The name of the release. For example, `Release v1.0.1`'
-    required: true
+    required: false
   body:
     description: 'Text describing the contents of the tag.'
     required: false


### PR DESCRIPTION
Currently, `release_name` input is flagged as required in `action.yml` despite #75 made it an optional parameter.

This PR just changes the `required` boolean to `false` in metadata to keep consistence.