### PR TITLE
Use a full commit SHA for actions-tagger

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -8,7 +8,7 @@ jobs:
   actions-tagger:
     runs-on: windows-latest
     steps:
-      - uses: Actions-R-Us/actions-tagger@latest
+      - uses: Actions-R-Us/actions-tagger@95c51c646e75db5c6b7d447e3087bcee58677341
         with:
           publish_latest: true
         env:


### PR DESCRIPTION
This changes the `versioning.yml` workflow to use a full commit SHA for the Actions-R-Us/actions-tagger action. Since this action has access to this repo's token, we should be especially careful and pin it to a specific SHA.